### PR TITLE
Do not show "lock screen" option in webmenu

### DIFF
--- a/scripts/views/LogoutView.coffee
+++ b/scripts/views/LogoutView.coffee
@@ -18,7 +18,9 @@ class LogoutView extends ViewMaster
     template: require "../templates/LogoutView.hbs"
 
     context: ->
-        actions = ["lock", "restart"]
+        actions = ["restart"]
+        if not @config.get("is_guest_session")
+            actions.unshift "lock"
         if @config.get("hostType") is "laptop"
             actions.unshift "hibernate"
             actions.unshift "sleep"

--- a/src/native.coffee
+++ b/src/native.coffee
@@ -83,6 +83,7 @@ config = _.extend({},
 
 config.hostType = require "./hosttype"
 config.feedback = logger.active and process.env.WM_FEEDBACK_ACTIVE
+config.is_guest_session = (process.env.GUEST_SESSION is "true")
 
 try
     puavoDomain = fs.readFileSync("/etc/puavo/domain").toString().trim()


### PR DESCRIPTION
Do not show "lock screen" option in webmenu in case GUEST_SESSION environment variable is set to "true".
